### PR TITLE
make .dummy-content css selector more specific

### DIFF
--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -1,7 +1,7 @@
 @import 'node_modules/ember-frost-theme/scss/frost-theme';
 @import 'node_modules/ember-frost-css-core/scss/frost-core';
 
-.dummy-content {
+.frost-application-bar ~ .dummy-content {
   position: relative;
   top: 50px;
 //  height: calc(100% - 50px);


### PR DESCRIPTION
#fix#

css properties were undesirably applied to other demos in frost-guide.