### PR TITLE
don't fail on dupe category register, testing fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,9 @@ Router.map(function () {
  * @param {string} config.description description
  * @param {string} config.icon icon
  * @param {string} config.pack icon pack
+ * @param {string} config.route navigate to route without registering on DSL
  * @param {string} config.url url to set href to
- * @param {boolean} config.openInNewTab flag to open in new tab
+ * @param {boolean} config.tabbed flag to open in new tab (default false)
  */
 ```
 

--- a/addon/services/frost-navigation.js
+++ b/addon/services/frost-navigation.js
@@ -15,16 +15,17 @@ export default Service.extend({
   categories: Ember.A(),
   _registerCategory (config = {}) {
     assert(A.categoryName, config.name)
-    let exists = this.categories.some(e => e.name === config.name)
-    assert(A.categoryExists, !exists)
-    let c = null
-    this.categories.push(c = {
-      name: config.name,
-      icon: config.icon,
-      pack: config.pack,
-      columns: config.columns || []
-    })
-    return c
+    let category = this.categories.find(e => e.name === config.name)
+
+    if (!category) {
+      this.categories.push(category = {
+        name: config.name,
+        icon: config.icon,
+        pack: config.pack,
+        columns: config.columns || []
+      })
+    }
+    return category
   },
   dismiss () {
     this.set('_activeCategory', null)

--- a/addon/templates/components/nav-modal.hbs
+++ b/addon/templates/components/nav-modal.hbs
@@ -26,6 +26,7 @@
                   name=route.name
                   route=route.route
                   url=route.url
+                  tabbed=route.tabbed
                 }}
               {{/each}}
             </div>

--- a/addon/templates/components/nav-route.hbs
+++ b/addon/templates/components/nav-route.hbs
@@ -1,4 +1,4 @@
-{{#unless url}}
+{{#if route}}
   {{#frost-link route disabled=true}}
     <div class='content'>
       <div class='nav-route-icon'>
@@ -15,7 +15,10 @@
     </div>
   {{/frost-link}}
 {{else}}
-  <a class='frost-link' href='{{url}}' target="_blank">
+  <a
+    class='frost-link'
+    href='{{url}}'
+    target="{{if tabbed '_blank'}}">
     <div class='content'>
       <div class='nav-route-icon'>
         {{frost-icon pack=pack icon=icon}}
@@ -30,4 +33,4 @@
       </div>
     </div>
   </a>
-{{/unless}}
+{{/if}}

--- a/addon/utils/bind-dsl.js
+++ b/addon/utils/bind-dsl.js
@@ -189,6 +189,7 @@ export default {
       ;(function (name, config = {}, callback = function () {}) {
         Ember.assert(A.route, config.route)
         self.DSL.route(config.route, config)
+
         let e = self.parent.type === 'section' ? self.element.routes : self.element[0].routes
         let route = self.top.name !== 'application'
           ? `${self.top.name}.${config.route}`
@@ -287,8 +288,9 @@ export default {
      * @param {string} config.description description
      * @param {string} config.icon icon
      * @param {string} config.pack icon pack
+     * @param {string} config.route navigate to route without registering on DSL
      * @param {string} config.url url to set href to
-     * @param {boolean} config.openInNewTab flag to open in new tab
+     * @param {boolean} config.tabbed flag to open in new tab
      */
     obj.link = function () {
       let args = argify(...arguments)
@@ -301,12 +303,12 @@ export default {
           description: config.description,
           icon: config.icon,
           pack: config.pack || 'frost',
+          route: config.route,
           url: config.url || name,
-          openInNewTab: config.openInNewTab || true
+          tabbed: config.tabbed || false
         })
         callback.call({
           parent: {
-            type: 'link',
             name,
             config
           }

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -34,7 +34,8 @@ Router.map(function () {
             url: 'http://google.ca',
             description: 'Go to Google',
             pack: 'dummy',
-            icon: 'sample'
+            icon: 'sample',
+            tabbed: true
           })
           this.link('http://google.ca')
           this.action('Action 1', {


### PR DESCRIPTION
@EWhite613 @sglanzer 
#patch#

# changelog 
 - No assertion on duplicate categories
     - When service checks to see if category exists, will either use pre-existing, or create one.
 - `this.link`
    - `this.app` will register against RouterDSL. For the case that a route already exists, and you just want to link to it, you can use `this.link('lorem', {route:'foobar'})`