### PR TITLE
allow for inline actions

### DIFF
--- a/addon/templates/components/nav-modal.hbs
+++ b/addon/templates/components/nav-modal.hbs
@@ -19,17 +19,21 @@
                 {{/if}}
               </div>
               <div class='body'>
-                {{#each section.routes as |route|}}
-                  {{nav-route
-                    description=route.description
-                    icon=route.icon
-                    pack=route.pack
-                    name=route.name
-                    route=route.route
-                    url=route.url
-                    tabbed=route.tabbed
-                    isVisible=route.isVisible
-                  }}
+                {{#each section.routes as |item|}}
+                  {{#if item.action}}
+                    {{nav-action item=item}}
+                  {{else}}
+                    {{nav-route
+                      description=item.description
+                      icon=item.icon
+                      pack=item.pack
+                      name=item.name
+                      route=item.route
+                      url=item.url
+                      tabbed=item.tabbed
+                      isVisible=item.isVisible
+                    }}
+                  {{/if}}
                 {{/each}}
               </div>
             </div>

--- a/addon/utils/bind-dsl.js
+++ b/addon/utils/bind-dsl.js
@@ -269,7 +269,12 @@ export default {
       Ember.assert(A.action, self.parent.type === 'section' || self.parent.type === 'column')
       ;(function (name, config = {}, callback = function () {}) {
         Ember.assert(A.actionConfig, config.action)
-        let e = self.parent.type === 'section' ? self.element.actions : self.element[0].actions
+        let e
+        if (config.inline) {
+          e = self.parent.type === 'section' ? self.element.routes : self.element[0].routes
+        } else {
+          e = self.parent.type === 'section' ? self.element.actions : self.element[0].actions
+        }
         e.push({
           name,
           description: config.description,

--- a/blueprints/ember-frost-navigation/index.js
+++ b/blueprints/ember-frost-navigation/index.js
@@ -11,7 +11,13 @@ module.exports = {
   afterInstall: function () {
     return this.addAddonsToProject({
       packages: [
-        {name: 'ember-frost-core', target: '>=0.0.14 <2.0.0'}
+        {
+          name: 'ember-frost-core',
+          target: '>=0.24.0 <2.0.0'
+        }, {
+          name: 'ember-block-slots',
+          target: '>=1.1.1 <2.0.0'
+        }
       ]
     })
   }

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -15,6 +15,13 @@ Router.map(function () {
       this.column('Column 1', {
         color: '#009eef'
       }, function () {
+        this.action('Action 1', {
+          action: 'myAction',
+          pack: 'dummy',
+          icon: 'sample',
+          description: 'My description',
+          inline: true
+        })
         this.app('App 1', {
           route: 'go',
           description: 'Description 1',


### PR DESCRIPTION
#patch#
@rox163 @sglanzer 

# changelog 
- Ability to add inline 'actions'
- Added ember block slots to blueprint


Usage:

```
this.action('Action 1', {
  action: 'myAction',
  pack: 'dummy',
  icon: 'sample',
  description: 'My description',
  inline: true
})
```

Where `inline: true` would determine whether it gets rendered in the actions tab or with the other apps.