### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ember-concurrency": "0.7.10",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-elsewhere": "0.3.0",
-    "ember-engines": "0.3.3",
+    "ember-engines": "0.2.4",
     "ember-export-application-global": "^1.0.4",
     "ember-frost-core": "0.27.3",
     "ember-hook": "^1.3.1",


### PR DESCRIPTION
Roll back `ember-engine`, updated by greenkeeper, as engine support doesn't yet exist in earlier versions of ember.