### PR TITLE
Addressing problems with nav-entries with query params

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Add the `{{frost-navigation}}` component to the template where you want the navi
 {{frost-navigation
   logo=(component ...)
   menu=(component ...)
-  
+
   navActions=(hash
     myAction=(action 'custom-action')
   )
@@ -175,6 +175,7 @@ Router.map(function () {
  * @param {string} config.icon icon
  * @param {string} config.pack icon pack
  * @param {string} config.route route to navigate to
+ * @param {object} config.params query params
  */
 ```
 ### `this.engine`
@@ -184,6 +185,7 @@ Router.map(function () {
  * @parent {type:[column, section]}
  * @param {string} config.package package name for engine
  * @param {string} config.route route name for nav entry
+ * @param {object} config.params query params
  * @param {string} config.description description
  * @param {string} config.icon icon
  * @param {string} config.pack icon pack

--- a/addon/components/nav-route.js
+++ b/addon/components/nav-route.js
@@ -44,11 +44,6 @@ export default Component.extend(PropTypesMixin, {
       navigation.dismiss()
       return
     }
-
-    if (get(this, 'route')) {
-      e.preventDefault()
-    }
-
-    navigation.transitionTo(get(this, 'route'))
   }
+
 })

--- a/addon/components/nav-route.js
+++ b/addon/components/nav-route.js
@@ -27,7 +27,8 @@ export default Component.extend(PropTypesMixin, {
     description: PropTypes.string,
     route: PropTypes.string,
     icon: PropTypes.string,
-    pack: PropTypes.string
+    pack: PropTypes.string,
+    params: PropTypes.object
   },
   getDefaultProps () {
     return {

--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -4,6 +4,7 @@
 $nav-modal-bg: rgba(51, 66, 79, .97);
 $nav-colum-border: rgba($frost-color-white, .3);
 $nav-route-focus-bg: rgba(0, 0, 0, .2);
+$nav-route-active-bg: rgba($nav-route-focus-bg, .05);
 $nav-route-focus-box-shadow: #fff;
 $frost-nav-border-left: rgba($frost-color-white, .2);
 $nav-category-border-right: rgba($frost-color-white, .2);
@@ -186,6 +187,19 @@ $z-index-modal-hidden: -1 !default;
             transition: color .2s ease;
             color: $frost-color-grey-6;
             font-size: $frost-font-s;
+          }
+
+          &.active {
+            background: $nav-route-active-bg;
+            box-shadow: 0 0 1px $nav-route-focus-box-shadow;
+
+            .nav-route-name {
+              color: $frost-color-lgrey-1;
+            }
+
+            .nav-route-description {
+              color: $frost-color-lgrey-3;
+            }
           }
 
           &:focus {

--- a/addon/templates/components/nav-route.hbs
+++ b/addon/templates/components/nav-route.hbs
@@ -1,5 +1,9 @@
 {{#if route}}
-  {{#frost-link route disabled=true hook=(concat hook '-link')}}
+  {{#frost-link
+      route
+      (hash isQueryParams=true values=params)
+      hook=(concat hook '-link')
+  }}
     <div class='content'>
       <div class='nav-route-icon'>
         {{#if icon}}

--- a/addon/templates/components/nav-section.hbs
+++ b/addon/templates/components/nav-section.hbs
@@ -24,6 +24,7 @@
         pack=item.pack
         name=item.name
         route=item.route
+        params=item.params
         url=item.url
         tabbed=item.tabbed
         isVisible=item.isVisible

--- a/addon/utils/bind-dsl.js
+++ b/addon/utils/bind-dsl.js
@@ -214,6 +214,7 @@ export default {
           icon: config.icon,
           pack: config.pack || 'frost',
           route,
+          params: config.params,
           isVisible: config.isVisible !== false
         })
         callback.call({
@@ -253,6 +254,7 @@ export default {
           icon: config.icon,
           pack: config.pack || 'frost',
           route,
+          params: config.params,
           isVisible: config.isVisible !== false
         })
         callback.call({

--- a/tests/dummy/app/helpers/inc.js
+++ b/tests/dummy/app/helpers/inc.js
@@ -1,7 +1,0 @@
-import Ember from 'ember'
-
-export function inc (params) {
-  return params[0] + 1
-}
-
-export default Ember.Helper.helper(inc)

--- a/tests/dummy/app/pods/demo/controller.js
+++ b/tests/dummy/app/pods/demo/controller.js
@@ -58,8 +58,9 @@ export default Controller.extend({
       log(item)
     },
     incrementCount () {
-      set(this, 'count', get(this, 'count') + 1)
-      set(get(this, 'customRouteObject'), 'params', {count: get(this, 'count')})
+      let count = get(this, 'count') + 1
+      set(this, 'count', count)
+      set(this, 'customRouteObject.params', {count})
     }
   }
 })

--- a/tests/dummy/app/pods/demo/controller.js
+++ b/tests/dummy/app/pods/demo/controller.js
@@ -7,7 +7,8 @@ const {
   inject: {
     service
   },
-  get
+  get,
+  set
 } = Ember
 // BEGIN-SNIPPET controller
 export default Controller.extend({
@@ -21,6 +22,31 @@ export default Controller.extend({
       clearDuration: 1000
     })
   },
+  init () {
+    this._super(...arguments)
+    let customRouteObject = Ember.Object.extend({
+      description: 'custom route',
+      icon: 'application',
+      pack: 'frost-nav',
+      name: 'Custom Route',
+      route: 'demo.go'
+    }).create()
+    set(this, 'customRouteObject', customRouteObject)
+    let columns = [
+      [
+        {
+          title: 'Custom Column',
+          routes: [
+            customRouteObject
+          ]
+        }
+      ]
+    ]
+    get(this, 'frostNavigation.categories').push({
+      name: 'Custom Category',
+      columns
+    })
+  },
   actions: {
     myAction (item) {
       this._notify(
@@ -30,6 +56,10 @@ export default Controller.extend({
         </code>`
       )
       log(item)
+    },
+    incrementCount () {
+      set(this, 'count', get(this, 'count') + 1)
+      set(get(this, 'customRouteObject'), 'params', {count: get(this, 'count')})
     }
   }
 })

--- a/tests/dummy/app/pods/demo/go/controller.js
+++ b/tests/dummy/app/pods/demo/go/controller.js
@@ -1,0 +1,5 @@
+import Ember from 'ember'
+
+export default Ember.Controller.extend({
+  queryParams: ['count']
+})

--- a/tests/dummy/app/pods/demo/go/template.hbs
+++ b/tests/dummy/app/pods/demo/go/template.hbs
@@ -1,1 +1,1 @@
-Went
+Went (count is {{count}})

--- a/tests/dummy/app/pods/demo/template.hbs
+++ b/tests/dummy/app/pods/demo/template.hbs
@@ -2,7 +2,6 @@
 {{frost-navigation
   navActions=(hash
     myAction=(action 'myAction')
-    increment=(action (mut count) (inc count))
   )
   logo=(component 'custom-logo'
     class='nav-category navigation-logo'

--- a/tests/dummy/app/pods/demo/template.hbs
+++ b/tests/dummy/app/pods/demo/template.hbs
@@ -26,6 +26,19 @@
     <div class='column item'>
       <div class='row item'>
         <div class='item'>
+          <h3>Click me</h3>
+
+          {{frost-button
+            icon='add'
+            priority='primary'
+            size='small'
+            onClick=(action 'incrementCount')
+          }}
+          {{count}}
+        </div>
+      </div>
+      <div class='row item'>
+        <div class='item'>
           <h3>Router</h3>
           {{code-snippet name='router.js'}}
         </div>


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
- Changes to css to show active state provided by link-to
- Add property `params`, of type hash that abuses ember's LinkTo Components way of parsing query params to allow for dynamic query parameters.

