### PR TITLE
update usage of deprecated describeComponent and describeModule methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "ember-redux": "^1.0.0",
     "ember-resolver": "^2.0.3",
     "ember-sinon": "~0.5.0",
+    "ember-test-utils": "^1.8.0",
     "ember-truth-helpers": "1.2.0",
     "eslint": "^3.0.0",
     "eslint-config-frost-standard": "^4.0.0",

--- a/tests/integration/components/nav-action-test.js
+++ b/tests/integration/components/nav-action-test.js
@@ -1,40 +1,34 @@
-import { expect } from 'chai'
-import { $hook, initialize } from 'ember-hook'
+import {expect} from 'chai'
+import {$hook, initialize} from 'ember-hook'
 import sinon from 'sinon'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
-import { beforeEach } from 'mocha'
 import hbs from 'htmlbars-inline-precompile'
+import {beforeEach, describe, it} from 'mocha'
 
-describeComponent(
-  'nav-action',
-  'Integration: NavActionComponent',
-  {
-    integration: true
-  },
-  function () {
-    beforeEach(function () {
-      initialize()
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
+
+const test = integration('nav-action')
+describe(test.label, function () {
+  test.setup()
+
+  beforeEach(function () {
+    initialize()
+  })
+  it('renders', function () {
+    this.render(hbs`{{nav-action}}`)
+    expect(this.$()).to.have.length(1)
+  })
+  it('calls perform action', function () {
+    let nav = Ember.Object.create({
+      performAction: sinon.spy()
     })
-    it('renders', function () {
-      this.render(hbs`{{nav-action}}`)
-      expect(this.$()).to.have.length(1)
-    })
-    it('calls perform action', function () {
-      let nav = Ember.Object.create({
-        performAction: sinon.spy()
-      })
-      this.set('_nav', nav)
-      this.set('_item', 'test')
-      this.render(hbs`{{nav-action
-        frostNavigation=_nav
-        item=_item
-        hook='nav-action'
-      }}`)
-      $hook('nav-action').click()
-      expect(nav.performAction.called).to.be.true
-    })
-  }
-)
+    this.set('_nav', nav)
+    this.set('_item', 'test')
+    this.render(hbs`{{nav-action
+      frostNavigation=_nav
+      item=_item
+      hook='nav-action'
+    }}`)
+    $hook('nav-action').click()
+    expect(nav.performAction.called).to.be.true
+  })
+})

--- a/tests/integration/components/nav-category-test.js
+++ b/tests/integration/components/nav-category-test.js
@@ -1,53 +1,45 @@
-import { expect } from 'chai'
-import { $hook, initialize } from 'ember-hook'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
-import {
-  describe,
-  beforeEach
-} from 'mocha'
+import {expect} from 'chai'
+import {$hook, initialize} from 'ember-hook'
 import hbs from 'htmlbars-inline-precompile'
-describeComponent(
-  'nav-category',
-  'Integration: NavCategoryComponent',
-  {
-    integration: true
-  },
-  function () {
-    beforeEach(function () {
-      initialize()
+import {beforeEach, describe, it} from 'mocha'
+
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
+
+const test = integration('nav-category')
+describe(test.label, function () {
+  test.setup()
+
+  beforeEach(function () {
+    initialize()
+  })
+  it('renders', function () {
+    this.render(hbs`{{nav-category}}`)
+    expect(this.$()).to.have.length(1)
+  })
+  describe('clicks', function () {
+    const helper = function (name, _activeCategory) {
+      this.set('_name', name)
+      this.set('_nav', Ember.Object.create({
+        _activeCategory,
+        dismiss () {
+          this.set('_activeCategory', null)
+        }
+      }))
+      this.render(hbs`{{nav-category
+        name=_name
+        frostNavigation=_nav
+        hook='nav-category'
+      }}`)
+      $hook('nav-category').click()
+    }
+    it('handles null case', function () {
+      helper.call(this, 'test', null)
     })
-    it('renders', function () {
-      this.render(hbs`{{nav-category}}`)
-      expect(this.$()).to.have.length(1)
+    it('handles not equal case', function () {
+      helper.call(this, 'test', '_test')
     })
-    describe('clicks', function () {
-      const helper = function (name, _activeCategory) {
-        this.set('_name', name)
-        this.set('_nav', Ember.Object.create({
-          _activeCategory,
-          dismiss () {
-            this.set('_activeCategory', null)
-          }
-        }))
-        this.render(hbs`{{nav-category
-          name=_name
-          frostNavigation=_nav
-          hook='nav-category'
-        }}`)
-        $hook('nav-category').click()
-      }
-      it('handles null case', function () {
-        helper.call(this, 'test', null)
-      })
-      it('handles not equal case', function () {
-        helper.call(this, 'test', '_test')
-      })
-      it('handles equal case', function () {
-        helper.call(this, 'test', 'test')
-      })
+    it('handles equal case', function () {
+      helper.call(this, 'test', 'test')
     })
-  }
-)
+  })
+})

--- a/tests/integration/components/nav-modal-outlet-test.js
+++ b/tests/integration/components/nav-modal-outlet-test.js
@@ -1,30 +1,25 @@
 /* jshint expr:true */
-import { expect } from 'chai'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
+import {expect} from 'chai'
 import hbs from 'htmlbars-inline-precompile'
+import {describe, it} from 'mocha'
 
-describeComponent(
-  'nav-modal-outlet',
-  'Integration: NavModalOutletComponent',
-  {
-    integration: true
-  },
-  function () {
-    it('renders', function () {
-      // Set any properties with set(this, 'myProperty', 'value');
-      // Handle any actions with this.on('myAction', function(val) { ... });
-      // Template block usage:
-      // this.render(hbs`
-      //   {{#nav-modal-outlet}}
-      //     template content
-      //   {{/nav-modal-outlet}}
-      // `);
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
-      this.render(hbs`{{nav-modal-outlet}}`)
-      expect(this.$()).to.have.length(1)
-    })
-  }
-)
+const test = integration('nav-modal-outlet')
+describe(test.label, function () {
+  test.setup()
+
+  it('renders', function () {
+    // Set any properties with set(this, 'myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
+    // Template block usage:
+    // this.render(hbs`
+    //   {{#nav-modal-outlet}}
+    //     template content
+    //   {{/nav-modal-outlet}}
+    // `);
+
+    this.render(hbs`{{nav-modal-outlet}}`)
+    expect(this.$()).to.have.length(1)
+  })
+})

--- a/tests/integration/components/nav-modal-test.js
+++ b/tests/integration/components/nav-modal-test.js
@@ -1,10 +1,9 @@
+import {expect} from 'chai'
 import Ember from 'ember'
-import { expect } from 'chai'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
+import {describe, it} from 'mocha'
+
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
 const {
   run
@@ -14,31 +13,27 @@ const {
   next
 } = run
 
-describeComponent(
-  'nav-modal',
-  'Integration: NavModalComponent',
-  {
-    integration: true
-  },
-  function () {
-    it('renders', function () {
-      this.render(hbs`{{nav-modal}}`)
-      expect(this.$()).to.have.length(1)
+const test = integration('nav-modal')
+describe(test.label, function () {
+  test.setup()
+
+  it('renders', function () {
+    this.render(hbs`{{nav-modal}}`)
+    expect(this.$()).to.have.length(1)
+  })
+  it('recomputes on _activeCategory change', function (done) {
+    let obj = Ember.Object.create({
+      _activeCategory: 'test'
     })
-    it('recomputes on _activeCategory change', function (done) {
-      let obj = Ember.Object.create({
-        _activeCategory: 'test'
-      })
-      this.set('_nav', obj)
-      this.render(hbs`{{nav-modal
-        frostNavigation=_nav
-        activeCategory=activeCategory
-      }}`)
-      obj.set('_activeCategory', 'recompute')
-      next(() => {
-        expect(this.get('activeCategory')).to.equal('recompute')
-        done()
-      })
+    this.set('_nav', obj)
+    this.render(hbs`{{nav-modal
+      frostNavigation=_nav
+      activeCategory=activeCategory
+    }}`)
+    obj.set('_activeCategory', 'recompute')
+    next(() => {
+      expect(this.get('activeCategory')).to.equal('recompute')
+      done()
     })
-  }
-)
+  })
+})

--- a/tests/integration/components/nav-route-test.js
+++ b/tests/integration/components/nav-route-test.js
@@ -1,49 +1,41 @@
-import { expect } from 'chai'
-import { $hook, initialize } from 'ember-hook'
-
+import {expect} from 'chai'
+import Ember from 'ember'
+import {$hook, initialize} from 'ember-hook'
+import hbs from 'htmlbars-inline-precompile'
+import {beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
-import { beforeEach } from 'mocha'
-import hbs from 'htmlbars-inline-precompile'
-import Ember from 'ember'
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
-describeComponent(
-  'nav-route',
-  'Integration: NavRouteComponent',
-  {
-    integration: true
-  },
-  function () {
-    beforeEach(function () {
-      initialize()
+const test = integration('nav-route')
+describe(test.label, function () {
+  test.setup()
+
+  beforeEach(function () {
+    initialize()
+  })
+  it('renders', function () {
+    this.render(hbs`{{nav-route}}`)
+    expect(this.$()).to.have.length(1)
+  })
+  it('handles click, and dismiss', function () {
+    let nav = Ember.Object.create({
+      dismiss: sinon.spy(),
+      transitionTo: sinon.spy()
     })
-    it('renders', function () {
-      this.render(hbs`{{nav-route}}`)
-      expect(this.$()).to.have.length(1)
-    })
-    it('handles click, and dismiss', function () {
-      let nav = Ember.Object.create({
-        dismiss: sinon.spy(),
-        transitionTo: sinon.spy()
-      })
-      this.set('_nav', nav)
-      this.render(hbs`{{nav-route
-        frostNavigation=_nav
-        route='test'
-        hook='nav-route'
-      }}`)
-      const e = (o) => Ember.$.Event('click', o)
-      ;[
-        e({shiftKey: true}),
-        e({metaKey: true}),
-        e({ctrlKey: true}),
-        e()
-      ].forEach(e => $hook('nav-route').trigger(e))
-      expect(nav.dismiss.calledThrice).to.be.true
-    })
-  }
-)
+    this.set('_nav', nav)
+    this.render(hbs`{{nav-route
+      frostNavigation=_nav
+      route='test'
+      hook='nav-route'
+    }}`)
+    const e = (o) => Ember.$.Event('click', o)
+    ;[
+      e({shiftKey: true}),
+      e({metaKey: true}),
+      e({ctrlKey: true}),
+      e()
+    ].forEach(e => $hook('nav-route').trigger(e))
+    expect(nav.dismiss.calledThrice).to.be.true
+  })
+})

--- a/tests/integration/components/nav-section-actions-test.js
+++ b/tests/integration/components/nav-section-actions-test.js
@@ -1,28 +1,23 @@
-import { expect } from 'chai'
-import sinon from 'sinon'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
+import {expect} from 'chai'
 import hbs from 'htmlbars-inline-precompile'
+import {describe, it} from 'mocha'
+import sinon from 'sinon'
 
-describeComponent(
-  'nav-section-actions',
-  'Integration: NavSectionActionsComponent',
-  {
-    integration: true
-  },
-  function () {
-    it('renders', function () {
-      this.render(hbs`{{nav-section-actions goBack=(action (mut showActions) false)}}`)
-      expect(this.$()).to.have.length(1)
-    })
-    it('goes back on click', function () {
-      let spy = sinon.spy()
-      this.set('goBack', spy)
-      this.render(hbs`{{nav-section-actions goBack=goBack}}`)
-      this.$('.nav-section-header').click()
-      expect(spy.called).to.be.true
-    })
-  }
-)
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
+
+const test = integration('nav-section-actions')
+describe(test.label, function () {
+  test.setup()
+
+  it('renders', function () {
+    this.render(hbs`{{nav-section-actions goBack=(action (mut showActions) false)}}`)
+    expect(this.$()).to.have.length(1)
+  })
+  it('goes back on click', function () {
+    let spy = sinon.spy()
+    this.set('goBack', spy)
+    this.render(hbs`{{nav-section-actions goBack=goBack}}`)
+    this.$('.nav-section-header').click()
+    expect(spy.called).to.be.true
+  })
+})

--- a/tests/integration/components/nav-section-test.js
+++ b/tests/integration/components/nav-section-test.js
@@ -1,20 +1,15 @@
-import { expect } from 'chai'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
+import {expect} from 'chai'
 import hbs from 'htmlbars-inline-precompile'
+import {describe, it} from 'mocha'
 
-describeComponent(
-  'nav-section',
-  'Integration: NavSectionComponent',
-  {
-    integration: true
-  },
-  function () {
-    it('renders', function () {
-      this.render(hbs`{{nav-section}}`)
-      expect(this.$()).to.have.length(1)
-    })
-  }
-)
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
+
+const test = integration('nav-section')
+describe(test.label, function () {
+  test.setup()
+
+  it('renders', function () {
+    this.render(hbs`{{nav-section}}`)
+    expect(this.$()).to.have.length(1)
+  })
+})

--- a/tests/unit/components/nav-action-test.js
+++ b/tests/unit/components/nav-action-test.js
@@ -1,26 +1,19 @@
-import { expect } from 'chai'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
+import {expect} from 'chai'
+import {describe, it} from 'mocha'
 
-describeComponent(
-  'nav-action',
-  'NavActionComponent',
-  {
-    // Specify the other units that are required for this test
-    needs: ['component:frost-link', 'helper:eq'],
-    unit: true
-  },
-  function () {
-    it('renders', function () {
-      // creates the component instance
-      let component = this.subject()
-      // renders the component on the page
-      this.render()
-      expect(component).to.be.ok
-      expect(component.getDefaultProps).to.be.a('array')
-      expect(this.$()).to.have.length(1)
-    })
-  }
-)
+import {unit} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
+
+const test = unit('nav-action', ['component:frost-link', 'helper:eq'])
+describe(test.label, function () {
+  test.setup()
+
+  it('renders', function () {
+    // creates the component instance
+    let component = this.subject()
+    // renders the component on the page
+    this.render()
+    expect(component).to.be.ok
+    expect(component.getDefaultProps).to.be.a('array')
+    expect(this.$()).to.have.length(1)
+  })
+})

--- a/tests/unit/components/nav-category-test.js
+++ b/tests/unit/components/nav-category-test.js
@@ -1,27 +1,20 @@
-import { expect } from 'chai'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
+import {expect} from 'chai'
+import {describe, it} from 'mocha'
 
-describeComponent(
-  'nav-category',
-  'NavCategoryComponent',
-  {
-    // Specify the other units that are required for this test
-    // needs: ['component:foo', 'helper:bar'],
-    unit: true
-  },
-  function () {
-    it('renders', function () {
-      // creates the component instance
-      let component = this.subject()
-      // renders the component on the page
-      this.render()
-      expect(component).to.be.ok
-      expect(component.getDefaultProps).to.be.a('array')
+import {unit} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
-      expect(this.$()).to.have.length(1)
-    })
-  }
-)
+const test = unit('nav-category')
+describe(test.label, function () {
+  test.setup()
+
+  it('renders', function () {
+    // creates the component instance
+    let component = this.subject()
+    // renders the component on the page
+    this.render()
+    expect(component).to.be.ok
+    expect(component.getDefaultProps).to.be.a('array')
+
+    expect(this.$()).to.have.length(1)
+  })
+})

--- a/tests/unit/components/nav-modal-test.js
+++ b/tests/unit/components/nav-modal-test.js
@@ -1,59 +1,51 @@
-import { expect } from 'chai'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
-import { beforeEach } from 'mocha'
+import {expect} from 'chai'
+import {beforeEach, describe, it} from 'mocha'
 
-describeComponent(
-  'nav-modal',
-  'NavModalComponent',
-  {
-    // Specify the other units that are required for this test
-    needs: ['service:frost-navigation'],
-    unit: true
-  },
-  function () {
-    let component
-    beforeEach(function () {
-      component = this.subject()
-      this.render()
+import {unit} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
+
+const test = unit('nav-modal', ['service:frost-navigation'])
+describe(test.label, function () {
+  test.setup()
+
+  let component
+  beforeEach(function () {
+    component = this.subject()
+    this.render()
+  })
+  it('renders', function () {
+    expect(component).to.be.ok
+    expect(this.$()).to.have.length(1)
+  })
+  it('handles actions', function () {
+    ;[
+      {
+        name: 'setView',
+        test () {
+          expect(component.get('showActions')).to.be.true
+        }
+      }
+    ].forEach(e => {
+      component.send(e.name, {})
+      if (e.hasOwnProperty('test')) {
+        e.test()
+      }
+      if (e.hasOwnProperty('cleanup')) {
+        e.cleanup()
+      }
     })
-    it('renders', function () {
-      expect(component).to.be.ok
-      expect(this.$()).to.have.length(1)
-    })
-    it('handles actions', function () {
-      ;[
+  })
+  it('computes categories correctly', function () {
+    let columns = [1, 2, 3]
+    let nav = component.get('frostNavigation')
+    component.set('activeCategory', 'test')
+    nav.setProperties({
+      categories: [
         {
-          name: 'setView',
-          test () {
-            expect(component.get('showActions')).to.be.true
-          }
+          name: 'test',
+          columns
         }
-      ].forEach(e => {
-        component.send(e.name, {})
-        if (e.hasOwnProperty('test')) {
-          e.test()
-        }
-        if (e.hasOwnProperty('cleanup')) {
-          e.cleanup()
-        }
-      })
+      ]
     })
-    it('computes categories correctly', function () {
-      let columns = [1, 2, 3]
-      let nav = component.get('frostNavigation')
-      component.set('activeCategory', 'test')
-      nav.setProperties({
-        categories: [
-          {
-            name: 'test',
-            columns
-          }
-        ]
-      })
-      expect(component.get('columns')).to.equal(columns)
-    })
-  }
-)
+    expect(component.get('columns')).to.equal(columns)
+  })
+})

--- a/tests/unit/components/nav-route-test.js
+++ b/tests/unit/components/nav-route-test.js
@@ -1,27 +1,20 @@
-import { expect } from 'chai'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
+import {expect} from 'chai'
+import {describe, it} from 'mocha'
 
-describeComponent(
-  'nav-route',
-  'NavRouteComponent',
-  {
-    // Specify the other units that are required for this test
-    needs: ['helper:hook'],
-    unit: true
-  },
-  function () {
-    it('renders', function () {
-      // creates the component instance
-      let component = this.subject()
-      // renders the component on the page
-      this.render()
-      expect(component).to.be.ok
-      expect(component.getDefaultProps).to.be.a('array')
+import {unit} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
-      expect(this.$()).to.have.length(1)
-    })
-  }
-)
+const test = unit('nav-route', ['helper:hook'])
+describe(test.label, function () {
+  test.setup()
+
+  it('renders', function () {
+    // creates the component instance
+    let component = this.subject()
+    // renders the component on the page
+    this.render()
+    expect(component).to.be.ok
+    expect(component.getDefaultProps).to.be.a('array')
+
+    expect(this.$()).to.have.length(1)
+  })
+})

--- a/tests/unit/components/nav-section-actions-test.js
+++ b/tests/unit/components/nav-section-actions-test.js
@@ -1,26 +1,19 @@
-import { expect } from 'chai'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
+import {expect} from 'chai'
+import {describe, it} from 'mocha'
 
-describeComponent(
-  'nav-section-actions',
-  'NavSectionActionsComponent',
-  {
-    // Specify the other units that are required for this test
-    needs: ['component:frost-icon'],
-    unit: true
-  },
-  function () {
-    it('renders', function () {
-      // creates the component instance
-      let component = this.subject()
-      // renders the component on the page
-      component.set('goBack', function () {})
-      this.render()
-      expect(component).to.be.ok
-      expect(this.$()).to.have.length(1)
-    })
-  }
-)
+import {unit} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
+
+const test = unit('nav-section-actions', ['component:frost-icon'])
+describe(test.label, function () {
+  test.setup()
+
+  it('renders', function () {
+    // creates the component instance
+    let component = this.subject()
+    // renders the component on the page
+    component.set('goBack', function () {})
+    this.render()
+    expect(component).to.be.ok
+    expect(this.$()).to.have.length(1)
+  })
+})

--- a/tests/unit/components/nav-section-test.js
+++ b/tests/unit/components/nav-section-test.js
@@ -1,25 +1,18 @@
-import { expect } from 'chai'
-import {
-  describeComponent,
-  it
-} from 'ember-mocha'
+import {expect} from 'chai'
+import {describe, it} from 'mocha'
 
-describeComponent(
-  'nav-section',
-  'NavSectionComponent',
-  {
-    // Specify the other units that are required for this test
-    // needs: ['component:foo', 'helper:bar'],
-    unit: true
-  },
-  function () {
-    it('renders', function () {
-      // creates the component instance
-      let component = this.subject()
-      // renders the component on the page
-      this.render()
-      expect(component).to.be.ok
-      expect(this.$()).to.have.length(1)
-    })
-  }
-)
+import {unit} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
+
+const test = unit('nav-section')
+describe(test.label, function () {
+  test.setup()
+
+  it('renders', function () {
+    // creates the component instance
+    let component = this.subject()
+    // renders the component on the page
+    this.render()
+    expect(component).to.be.ok
+    expect(this.$()).to.have.length(1)
+  })
+})

--- a/tests/unit/services/frost-navigation-test.js
+++ b/tests/unit/services/frost-navigation-test.js
@@ -1,64 +1,61 @@
-import { expect } from 'chai'
+import {expect} from 'chai'
 import Ember from 'ember'
-import {
-  describeModule,
-  it
-} from 'ember-mocha'
-import { beforeEach } from 'mocha'
+import {setupTest} from 'ember-mocha'
+import {beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 
-describeModule(
-  'service:frost-navigation',
-  'FrostNavigationService',
-  function () {
-    let service
-    beforeEach(function () {
-      service = this.subject()
+describe('Unit / Service / frost-navigation', function () {
+  setupTest('service:frost-navigation', {
+    unit: true
+  })
+
+  let service
+  beforeEach(function () {
+    service = this.subject()
+  })
+  it('exists', function () {
+    expect(service).to.be.ok
+  })
+  it('adds categories correctly', function () {
+    service._registerCategory({
+      name: 'add new category'
     })
-    it('exists', function () {
-      expect(service).to.be.ok
+    expect(service.categories).to.not.be.empty
+  })
+  it('returns existing category', function () {
+    let name = 'existing category'
+    service.set('categories', Ember.A())
+    service.get('categories').pushObject({
+      name
     })
-    it('adds categories correctly', function () {
-      service._registerCategory({
-        name: 'add new category'
-      })
-      expect(service.categories).to.not.be.empty
+    service._registerCategory({
+      name
     })
-    it('returns existing category', function () {
-      let name = 'existing category'
-      service.set('categories', Ember.A())
-      service.get('categories').pushObject({
-        name
-      })
-      service._registerCategory({
-        name
-      })
-      expect(service.categories.length).to.equal(1)
+    expect(service.categories.length).to.equal(1)
+  })
+  it('dismisses', function () {
+    service.set('_activeCategory', 'test')
+    expect(service.get('_activeCategory')).to.equal('test')
+    service.dismiss()
+    expect(service.get('_activeCategory')).to.equal(null)
+  })
+  it('performs action', function () {
+    let spy = sinon.spy()
+    service.set('_actions', {
+      testAction: spy
     })
-    it('dismisses', function () {
-      service.set('_activeCategory', 'test')
-      expect(service.get('_activeCategory')).to.equal('test')
-      service.dismiss()
-      expect(service.get('_activeCategory')).to.equal(null)
+    service.set('_activeCategory', 'test')
+    service.performAction({
+      dismiss: true,
+      action: 'testAction'
     })
-    it('performs action', function () {
-      let spy = sinon.spy()
-      service.set('_actions', {
-        testAction: spy
-      })
-      service.set('_activeCategory', 'test')
-      service.performAction({
-        dismiss: true,
-        action: 'testAction'
-      })
-      expect(spy.called).to.be.true
-      expect(service.get('_activeCategory')).to.be.null
-    })
-    it('transitions to a route', function () {
-      let spy = sinon.spy()
-      service.set('dismiss', spy)
-      service.transitionTo('index')
-      expect(spy.called).to.be.true
-    })
-  }
-)
+    expect(spy.called).to.be.true
+    expect(service.get('_activeCategory')).to.be.null
+  })
+  it('transitions to a route', function () {
+    let spy = sinon.spy()
+    service.set('dismiss', spy)
+    service.transitionTo('index')
+    expect(spy.called).to.be.true
+  })
+})


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #patch# - backwards-compatible bug fix
 - [X] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

Closes: https://github.com/ciena-frost/ember-frost-navigation/issues/192

# CHANGELOG
* **Updated** integration/unit tests to remove the deprecated use of `describeComponent()`
* **Updated** unit tests to remove the deprecated use of `describeModule()`
* **Added** ember-test-utils dependency for usage in testing