### PR TITLE
Update to new linting functionality

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -1,0 +1,11 @@
+{
+  "plugins": {
+    "lint": {
+      "list-item-indent": false,
+      "maximum-line-length": 119
+    }
+  },
+  "settings": {
+    "commonmark": true
+  }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ deploy:
     branch: master
     condition: "$EMBER_TRY_SCENARIO = 'default'"
     node: 'stable'
-    tags: false
+    tags: true
 after_deploy:
 - .travis/publish-gh-pages.sh
 notifications:

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ module.exports = {
     if (this.options.babel.optional.indexOf('es7.decorators') === -1) {
       this.options.babel.optional.push('es7.decorators')
     }
+    // eslint-disable-next-line no-unused-expressions
     this._super.init && this._super.init.apply(this, arguments)
   },
   included: function (app) {

--- a/package.json
+++ b/package.json
@@ -9,12 +9,9 @@
   },
   "scripts": {
     "build": "ember build",
+    "lint": "lint-all-the-things",
     "start": "ember server",
-    "test": "npm run lint && COVERAGE=true ember test",
-    "eslint": "eslint *.js addon app config tests",
-    "sass-lint": "sass-lint -q -v",
-    "md-lint": "remark *.md",
-    "lint": "npm run eslint && npm run sass-lint && npm run md-lint"
+    "test": "npm run lint && COVERAGE=true ember test"
   },
   "repository": "git@github.com:ciena-frost/ember-frost-navigation.git",
   "engines": {
@@ -53,18 +50,13 @@
     "ember-redux": "^1.0.0",
     "ember-resolver": "^2.0.3",
     "ember-sinon": "~0.5.0",
-    "ember-test-utils": "^1.8.0",
+    "ember-test-utils": "^1.10.7",
     "ember-truth-helpers": "1.2.0",
-    "eslint": "^3.0.0",
-    "eslint-config-frost-standard": "^4.0.0",
     "frost-guide-custom-routing": "0.0.4",
     "liquid-fire": "~0.26.0",
     "loader.js": "^4.0.1",
     "redux": "3.6.0",
     "redux-thunk": "2.1.0",
-    "remark-cli": "^2.0.0",
-    "remark-lint": "^5.1.0",
-    "sass-lint": "^1.0.0",
     "svg4everybody": "^2.1.0"
   },
   "keywords": [

--- a/tests/integration/components/nav-action-test.js
+++ b/tests/integration/components/nav-action-test.js
@@ -29,6 +29,6 @@ describe(test.label, function () {
       hook='nav-action'
     }}`)
     $hook('nav-action').click()
-    expect(nav.performAction.called).to.be.true
+    expect(nav.performAction.called).to.equal(true)
   })
 })

--- a/tests/integration/components/nav-route-test.js
+++ b/tests/integration/components/nav-route-test.js
@@ -36,6 +36,6 @@ describe(test.label, function () {
       e({ctrlKey: true}),
       e()
     ].forEach(e => $hook('nav-route').trigger(e))
-    expect(nav.dismiss.calledThrice).to.be.true
+    expect(nav.dismiss.calledThrice).to.equal(true)
   })
 })

--- a/tests/integration/components/nav-section-actions-test.js
+++ b/tests/integration/components/nav-section-actions-test.js
@@ -18,6 +18,6 @@ describe(test.label, function () {
     this.set('goBack', spy)
     this.render(hbs`{{nav-section-actions goBack=goBack}}`)
     this.$('.nav-section-header').click()
-    expect(spy.called).to.be.true
+    expect(spy.called).to.equal(true)
   })
 })

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,4 +1,4 @@
 import resolver from './helpers/resolver'
-import { setResolver } from 'ember-mocha'
+import {setResolver} from 'ember-mocha'
 
 setResolver(resolver)

--- a/tests/unit/components/nav-action-test.js
+++ b/tests/unit/components/nav-action-test.js
@@ -12,7 +12,6 @@ describe(test.label, function () {
     let component = this.subject()
     // renders the component on the page
     this.render()
-    expect(component).to.be.ok
     expect(component.getDefaultProps).to.be.a('array')
     expect(this.$()).to.have.length(1)
   })

--- a/tests/unit/components/nav-category-test.js
+++ b/tests/unit/components/nav-category-test.js
@@ -12,7 +12,6 @@ describe(test.label, function () {
     let component = this.subject()
     // renders the component on the page
     this.render()
-    expect(component).to.be.ok
     expect(component.getDefaultProps).to.be.a('array')
 
     expect(this.$()).to.have.length(1)

--- a/tests/unit/components/nav-modal-test.js
+++ b/tests/unit/components/nav-modal-test.js
@@ -13,7 +13,6 @@ describe(test.label, function () {
     this.render()
   })
   it('renders', function () {
-    expect(component).to.be.ok
     expect(this.$()).to.have.length(1)
   })
   it('handles actions', function () {
@@ -21,7 +20,7 @@ describe(test.label, function () {
       {
         name: 'setView',
         test () {
-          expect(component.get('showActions')).to.be.true
+          expect(component.get('showActions')).to.equal(true)
         }
       }
     ].forEach(e => {

--- a/tests/unit/components/nav-route-test.js
+++ b/tests/unit/components/nav-route-test.js
@@ -12,7 +12,6 @@ describe(test.label, function () {
     let component = this.subject()
     // renders the component on the page
     this.render()
-    expect(component).to.be.ok
     expect(component.getDefaultProps).to.be.a('array')
 
     expect(this.$()).to.have.length(1)

--- a/tests/unit/components/nav-section-actions-test.js
+++ b/tests/unit/components/nav-section-actions-test.js
@@ -13,7 +13,6 @@ describe(test.label, function () {
     // renders the component on the page
     component.set('goBack', function () {})
     this.render()
-    expect(component).to.be.ok
     expect(this.$()).to.have.length(1)
   })
 })

--- a/tests/unit/components/nav-section-test.js
+++ b/tests/unit/components/nav-section-test.js
@@ -9,10 +9,9 @@ describe(test.label, function () {
 
   it('renders', function () {
     // creates the component instance
-    let component = this.subject()
+    this.subject()
     // renders the component on the page
     this.render()
-    expect(component).to.be.ok
     expect(this.$()).to.have.length(1)
   })
 })

--- a/tests/unit/services/frost-navigation-test.js
+++ b/tests/unit/services/frost-navigation-test.js
@@ -1,5 +1,6 @@
 import {expect} from 'chai'
 import Ember from 'ember'
+const {A} = Ember
 import {setupTest} from 'ember-mocha'
 import {beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
@@ -13,18 +14,16 @@ describe('Unit / Service / frost-navigation', function () {
   beforeEach(function () {
     service = this.subject()
   })
-  it('exists', function () {
-    expect(service).to.be.ok
-  })
   it('adds categories correctly', function () {
     service._registerCategory({
       name: 'add new category'
     })
-    expect(service.categories).to.not.be.empty
+    console.log('service: ', service.categories.length)
+    expect(service.categories.length).to.equal(1)
   })
   it('returns existing category', function () {
     let name = 'existing category'
-    service.set('categories', Ember.A())
+    service.set('categories', A())
     service.get('categories').pushObject({
       name
     })
@@ -49,13 +48,13 @@ describe('Unit / Service / frost-navigation', function () {
       dismiss: true,
       action: 'testAction'
     })
-    expect(spy.called).to.be.true
-    expect(service.get('_activeCategory')).to.be.null
+    expect(spy.called).to.equal(true)
+    expect(service.get('_activeCategory')).to.equal(null)
   })
   it('transitions to a route', function () {
     let spy = sinon.spy()
     service.set('dismiss', spy)
     service.transitionTo('index')
-    expect(spy.called).to.be.true
+    expect(spy.called).to.equal(true)
   })
 })

--- a/tests/unit/services/frost-navigation-test.js
+++ b/tests/unit/services/frost-navigation-test.js
@@ -18,7 +18,6 @@ describe('Unit / Service / frost-navigation', function () {
     service._registerCategory({
       name: 'add new category'
     })
-    console.log('service: ', service.categories.length)
     expect(service.categories.length).to.equal(1)
   })
   it('returns existing category', function () {


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [X] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

Closes: https://github.com/ciena-frost/ember-frost-navigation/issues/194

# CHANGELOG
* **Updated** Travis to only publish when git tags are added in preparation for non-version bump pull requests.
* **Updated** linting to use linting tools from `ember-test-utils`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ciena-frost/ember-frost-navigation/195)
<!-- Reviewable:end -->
