### PR TITLE
Add guard for component destroying

### DIFF
--- a/addon/components/nav-category.js
+++ b/addon/components/nav-category.js
@@ -60,6 +60,10 @@ export default Component.extend({
       frostNavigation.dismiss()
       if (name !== active) { // click on another tab
         run.later(() => {
+          if (this.isDestroying || this.isDestoryed) {
+            return
+          }
+
           set(frostNavigation, '_activeCategory', name)
         }, 250)
       }

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -9,7 +9,6 @@ var Router = EmberRouter.extend({
 // BEGIN-SNIPPET router
 Router.map(function () {
   this.route('test', {path: '/test/:id'})
-  this.route('test', {path: '/test/:id'})
 
   this.nav('demo', {path: '/'}, function () {
     this.category('Category 1', {

--- a/tests/unit/components/nav-category-test.js
+++ b/tests/unit/components/nav-category-test.js
@@ -157,14 +157,33 @@ describe(test.label, function () {
           expect(navigation._activeCategory).to.equal(null)
         })
 
-        describe('after the run.later() kicks off', function () {
+        describe('when the component is destroyed', function () {
           beforeEach(function () {
-            const func = run.later.lastCall.args[0]
-            func()
+            component.destroy()
           })
 
-          it('should set _activeCategory', function () {
-            expect(navigation._activeCategory).to.equal('foo-bar')
+          describe('after the run.later() kicks off', function () {
+            beforeEach(function () {
+              const func = run.later.lastCall.args[0]
+              func()
+            })
+
+            it('should not set _activeCategory', function () {
+              expect(navigation._activeCategory).to.equal(null)
+            })
+          })
+        })
+
+        describe('when the component is all good', function () {
+          describe('after the run.later() kicks off', function () {
+            beforeEach(function () {
+              const func = run.later.lastCall.args[0]
+              func()
+            })
+
+            it('should set _activeCategory', function () {
+              expect(navigation._activeCategory).to.equal('foo-bar')
+            })
           })
         })
       })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* **Fixed** bug where destroyed component tried to update `frost-navigation` service
