### PR TITLE
Add guard against destroyed service

### DIFF
--- a/addon/components/nav-category.js
+++ b/addon/components/nav-category.js
@@ -60,7 +60,7 @@ export default Component.extend({
       frostNavigation.dismiss()
       if (name !== active) { // click on another tab
         run.later(() => {
-          if (this.isDestroying || this.isDestoryed) {
+          if (this.isDestroying || this.isDestoryed || frostNavigation.isDestroying || frostNavigation.isDestroyed) {
             return
           }
 

--- a/addon/components/nav-category.js
+++ b/addon/components/nav-category.js
@@ -60,7 +60,7 @@ export default Component.extend({
       frostNavigation.dismiss()
       if (name !== active) { // click on another tab
         run.later(() => {
-          if (this.isDestroying || this.isDestoryed || frostNavigation.isDestroying || frostNavigation.isDestroyed) {
+          if (this.isDestroying || this.isDestroyed || frostNavigation.isDestroying || frostNavigation.isDestroyed) {
             return
           }
 

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "remark-lint": "^5.1.0",
     "sass-lint": "^1.0.0",
     "sinon-chai": "^2.8.0",
-    "typescript": "^1.8.10"
+    "typescript": "^2.0.0"
   },
   "keywords": [
     "ember-addon",

--- a/tests/unit/components/nav-category-test.js
+++ b/tests/unit/components/nav-category-test.js
@@ -174,7 +174,41 @@ describe(test.label, function () {
           })
         })
 
-        describe('when the component is all good', function () {
+        describe('when the service is destroying', function () {
+          beforeEach(function () {
+            navigation.isDestroying = true
+          })
+
+          describe('after the run.later() kicks off', function () {
+            beforeEach(function () {
+              const func = run.later.lastCall.args[0]
+              func()
+            })
+
+            it('should not set _activeCategory', function () {
+              expect(navigation._activeCategory).to.equal(null)
+            })
+          })
+        })
+
+        describe('when the service is destroyed', function () {
+          beforeEach(function () {
+            navigation.isDestroyed = true
+          })
+
+          describe('after the run.later() kicks off', function () {
+            beforeEach(function () {
+              const func = run.later.lastCall.args[0]
+              func()
+            })
+
+            it('should not set _activeCategory', function () {
+              expect(navigation._activeCategory).to.equal(null)
+            })
+          })
+        })
+
+        describe('when the component and service are all good', function () {
           describe('after the run.later() kicks off', function () {
             beforeEach(function () {
               const func = run.later.lastCall.args[0]


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
 * **Added** a guard against `frost-navigation` service being destroyed when timeout finishes (attempting to fix [#204](https://github.com/ciena-frost/ember-frost-navigation/issues/204)) 