### PR TITLE
Upgrade to pr-bumper@2.x

### DIFF
--- a/.pr-bumper.json
+++ b/.pr-bumper.json
@@ -1,3 +1,10 @@
 {
-  "dependencySnapshotFile": ""
+  "features": {
+    "changelog": {
+      "enabled": true
+    },
+    "coverage": {
+      "enabled": true
+    }
+  }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 language: node_js
 
 node_js:
-- '6.9.1'
+- '6.11.0'
 - 'stable'
 
 addons:
@@ -38,7 +38,7 @@ matrix:
 
 before_install:
 - npm config set spin false
-- npm install -g coveralls pr-bumper@^1.0.0
+- npm install -g coveralls pr-bumper@^2.0.0
 - $(npm root -g)/pr-bumper/.travis/maybe-check-scope.sh
 
 install:
@@ -66,7 +66,7 @@ deploy:
   on:
     all_branches: true
     condition: "$EMBER_TRY_SCENARIO = 'default'"
-    node: '6.9.1'
+    node: '6.11.0'
     tags: true
 
 notifications:

--- a/.travis/maybe-bump-version.sh
+++ b/.travis/maybe-bump-version.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "$TRAVIS_NODE_VERSION" != "6.9.1" ]
+if [ "$TRAVIS_NODE_VERSION" != "6.11.0" ]
 then
   echo "Skipping version bump for TRAVIS_NODE_VERSION ${TRAVIS_NODE_VERSION}"
   exit 0

--- a/.travis/maybe-publish-coverage.sh
+++ b/.travis/maybe-publish-coverage.sh
@@ -8,7 +8,7 @@ then
   exit 0
 fi
 
-if [ "$TRAVIS_NODE_VERSION" != "6.9.1" ]
+if [ "$TRAVIS_NODE_VERSION" != "6.11.0" ]
 then
   echo "Skipping coverage publish for TRAVIS_NODE_VERSION ${TRAVIS_NODE_VERSION}"
   exit 0

--- a/.travis/maybe-publish-gh-pages.sh
+++ b/.travis/maybe-publish-gh-pages.sh
@@ -18,6 +18,18 @@ then
     exit 0
 fi
 
+if [ "$TRAVIS_NODE_VERSION" != "6.11.0" ]
+then
+  echo "Skipping gh-pages publish for TRAVIS_NODE_VERSION ${TRAVIS_NODE_VERSION}"
+  exit 0
+fi
+
+if [ "$EMBER_TRY_SCENARIO" != "default" ]
+then
+  echo "Skipping gh-pages publish for EMBER_TRY_SCENARIO ${EMBER_TRY_SCENARIO}"
+  exit 0
+fi
+
 ember build --prod
 git clone https://${GITHUB_TOKEN}@github.com/${TRAVIS_REPO_SLUG} ${TMP_GH_PAGES_DIR} > /dev/null 2>&1
 cd ${TMP_GH_PAGES_DIR}


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

This isn't really a patch, but want to make sure publishing still works with the new `pr-bumper`, so calling it a patch. 

# CHANGELOG
* **Upgraded** `pr-bumper` to support pre-releases so we can create a `8.0-beta` branch. 
