### PR TITLE
Dismiss modal when clicking current route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # dependencies
 /node_modules
 /bower_components
+yarn.lock
 
 # misc
 /.sass-cache

--- a/addon/components/nav-route.js
+++ b/addon/components/nav-route.js
@@ -9,6 +9,7 @@ export default Component.extend({
   // == Dependencies ==========================================================
 
   frostNavigation: inject.service(),
+  routingService: inject.service('-routing'),
 
   // == Keyword Properties ====================================================
 
@@ -39,8 +40,9 @@ export default Component.extend({
 
   click (e) {
     const navigation = this.get('frostNavigation')
+    const onTargetRoute = (this.get('routingService.currentRouteName') === this.get('route'))
 
-    if (e.metaKey || e.shiftKey || e.ctrlKey) {
+    if (e.metaKey || e.shiftKey || e.ctrlKey || onTargetRoute) {
       navigation.dismiss()
       return
     }

--- a/package.json
+++ b/package.json
@@ -86,9 +86,9 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.7",
-    "ember-computed-decorators": "0.3.0",
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-sass": "5.6.0",
+    "ember-computed-decorators": "0.3.0",
     "ember-frost-core": "1.23.10",
     "liquid-fire": "0.27.3"
   },

--- a/tests/unit/components/nav-route-test.js
+++ b/tests/unit/components/nav-route-test.js
@@ -28,7 +28,7 @@ describe(test.label, function () {
   })
 
   describe('.click()', function () {
-    let navigation, evt
+    let navigation, evt, getStub
     beforeEach(function () {
       navigation = {
         dismiss: sandbox.stub()
@@ -40,7 +40,9 @@ describe(test.label, function () {
         shiftKey: false
       }
 
-      sandbox.stub(component, 'get').withArgs('frostNavigation').returns(navigation)
+      getStub = sandbox.stub(component, 'get').withArgs('frostNavigation').returns(navigation)
+      getStub.withArgs('route').returns('a-route')
+      getStub.withArgs('routingService.currentRouteName').returns('a-different-route')
     })
 
     describe('when no modifier keys are pressed', function () {
@@ -78,6 +80,17 @@ describe(test.label, function () {
     describe('when ctrl key is pressed', function () {
       beforeEach(function () {
         evt.ctrlKey = true
+        component.click(evt)
+      })
+
+      it('should call .dismiss()', function () {
+        expect(navigation.dismiss).to.have.callCount(1)
+      })
+    })
+
+    describe('when currentRouteName === targetRoute', function () {
+      beforeEach(function () {
+        getStub.withArgs('routingService.currentRouteName').returns('a-route')
         component.click(evt)
       })
 


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* Fixed a bug where clicking a nav-route targeting the current route would leave the modal open
